### PR TITLE
Revise and expand supported boards documentation

### DIFF
--- a/src/content/docs/en/fydelix/flashing.md
+++ b/src/content/docs/en/fydelix/flashing.md
@@ -111,10 +111,10 @@ For development and debugging, requires an SWD debugger (e.g., J-Link, DAP-Link)
 
 | Board | Firmware Name |
 |-------|---------------|
-| NeutronRC F435 SE | `fydelix-NeutronRCF435SE` |
-| NeutronRC F435 MINI | `fydelix-NeutronRCF435MINI` |
-| Hummingbird 200RS | `fydelix-Hummingbird200RS` |
-| Hummingbird 255 V1 | `fydelix-Hummingbird255V1REVA` |
+| NeutronRCF435SE | `fydelix-NeutronRCF435SE` |
+| NeutronRCF435MINI | `fydelix-NeutronRCF435MINI` |
+| Hummingbird200RS | `fydelix-Hummingbird200RS` |
+| Hummingbird255V1 | `fydelix-Hummingbird255V1REVA` |
 | StingerBee | `fydelix-StingerBee` |
 
 ---

--- a/src/content/docs/en/fydelix/supported-boards.md
+++ b/src/content/docs/en/fydelix/supported-boards.md
@@ -1,29 +1,35 @@
 ---
 title: Supported Hardware
-description: Flight controllers and sensors supported by Fidelity X
+description: Flight controllers and sensors compatible with Fidelity X
 ---
 
-Fidelity X supports multiple flight controllers based on AT32F43x.
+Fidelity X currently supports a range of flight controllers based on the AT32F43x MCU family.
 
 ---
 
 ## Officially Supported Flight Controllers
 
-The following flight controllers have been fully tested with official support:
+The following flight controllers have been thoroughly tested and receive official support:
 
 ### NeutronRC Series
 
-#### NeutronRC F435 SE
+#### NeutronRCF435SE
 
 | Item | Specification |
 |------|---------------|
 | MCU | AT32F435RGT7 |
 | Package | LQFP64 |
 | Gyro | BMI270 |
-| Size | 30.5 x 30.5mm |
+| Mounting | 20x20mm / 30.5x30.5mm |
 | Firmware | `fydelix-NeutronRCF435SE` |
 
-#### NeutronRC F435 MINI
+A versatile classic that accommodates both 20x20mm and 30.5x30.5mm mounting patterns, making it highly adaptable for various builds.
+
+:::danger[Read Before Purchasing]
+NeutronRC has released a newer revision of the F435SE under the same name, but equipped with an **ICM42688P** gyroscope. **Fidelity X does NOT support this newer revision**. Before purchasing, always confirm with the seller that the unit uses a **BMI270** gyroscope.
+:::
+
+#### NeutronRCF435MINI
 
 | Item | Specification |
 |------|---------------|
@@ -33,95 +39,140 @@ The following flight controllers have been fully tested with official support:
 | Size | 20 x 20mm |
 | Firmware | `fydelix-NeutronRCF435MINI` |
 
+Commonly found in NeutronRC's AIO (All-In-One) integrated products.
+
+:::caution[Important Notes]
+- **Gyroscope Compatibility**: Only the BMI270 variant is supported; units equipped with ICM42688P are NOT compatible
+- **ESC Firmware Requirements**: Only **Bluejay**, **AM32**, and **BLHeli_32** ESC firmware are supported. Other ESC firmware is not compatible, with no plans to add support
+:::
+
 ---
 
-### Hummingbird Series
+### NewBeeDrone Series
 
 #### Hummingbird 200RS
 
 | Item | Specification |
 |------|---------------|
 | MCU | AT32F435 |
-| Gyro | BMI270 / ICM-42688-P |
+| Gyro | BMI270 / ICM42688P |
 | Size | 20 x 20mm |
-| Firmware | `fydelix-Hummingbird200RS` |
+| Firmware | `fydelix-Hummingbird200RS` / `fydelix-Hummingbird200RS_legacy` |
 
 #### Hummingbird 255 V1
 
 | Item | Specification |
 |------|---------------|
 | MCU | AT32F435 |
-| Gyro | BMI270 |
+| Gyro | BMI270 / ICM42688P |
 | Size | 25.5 x 25.5mm |
-| Firmware | `fydelix-Hummingbird255V1REVA` |
+| Firmware | `fydelix-Hummingbird255V1REVA` / `fydelix-Hummingbird255V1REVA_legacy` |
 
----
-
-### Other Controllers
+:::tip[Choosing the Right Firmware]
+The Hummingbird series comes in two gyroscope variants. Verify your hardware before flashing:
+- **Without `_legacy` suffix**: For **BMI270** gyroscope
+- **With `_legacy` suffix**: For **ICM42688P** gyroscope
+:::
 
 #### StingerBee
 
 | Item | Specification |
 |------|---------------|
 | MCU | AT32F435 |
-| Gyro | BMI270 |
+| Gyro | ICM42688P |
+| Type | BNF (Bind-and-Fly) Kit |
 | Use Case | Tiny Whoop |
 | Firmware | `fydelix-StingerBee` |
 
+The StingerBee is a complete BNF (Bind-and-Fly) kit from NewBeeDrone—not a standalone flight controller board.
+
+:::note[Factory Preset Information]
+The StingerBee firmware ships with factory presets customized by NewBeeDrone. Performing a factory reset will restore the **NewBeeDrone factory presets**, not the Fidelity X defaults.
+:::
+
 ---
 
-## Choosing the Right Firmware
+### Open Source Designs
 
-### Firmware Naming Convention
+#### ESMRPROTO2
 
-```
-fydelix-<board>-<version>-<commit>.hex
+| Item | Specification |
+|------|---------------|
+| MCU | AT32F435 |
+| Gyro | BMI270 / ICM42688P |
+| Type | Open-Source Hardware Design |
+| Firmware | `fydelix-ESMRPROTO2` / `fydelix-ESMRPROTO2_legacy` |
+
+ESMRPROTO2 is a widely adopted open-source flight controller schematic used by numerous commercial manufacturers and DIY enthusiasts alike. If your flight controller is based on this reference design, this firmware should be compatible.
+
+:::tip[Choosing the Right Firmware]
+The same selection rules apply as for the Hummingbird series:
+- **Without `_legacy` suffix**: For **BMI270** gyroscope
+- **With `_legacy` suffix**: For **ICM42688P** gyroscope
+:::
+
+---
+
+## Firmware Selection Guide
+
+### Naming Convention
+
+```text
+fydelix-<board>-<version>-<git-commit>.hex
 ```
 
 **Example**: `fydelix-NeutronRCF435MINI-0.1.3-8ab496d.hex`
 
-### Legacy Versions
+### Understanding Legacy Versions
 
-Some flight controllers have firmware with `_legacy` suffix for older hardware compatibility.
+Firmware files with the `_legacy` suffix are specifically built for flight controllers equipped with the **ICM42688P** gyroscope.
 
-:::tip[How to Choose]
-- Try the regular version first
-- If you encounter issues, try the legacy version
+| Firmware Type | Target Gyroscope |
+|---------------|------------------|
+| Standard (no suffix) | BMI270 |
+| Legacy (`_legacy` suffix) | ICM42688P |
+
+:::caution[Flash the Correct Version]
+Flashing the wrong firmware variant will cause the gyroscope to malfunction, preventing the flight controller from arming. Always verify your gyroscope model before flashing.
 :::
 
 ---
 
 ## Supported MCUs
 
-| Chip | Package | Flash | RAM |
-|------|---------|-------|-----|
-| AT32F435CGU7 | QFN48 | 1MB | 384KB |
-| AT32F435RGT7 | LQFP64 | 1MB | 384KB |
-| AT32F437VMT7 | LQFP100 | 4MB | 512KB |
+### AT32 Series
+
+| Chip | Package | Flash | RAM | Status |
+|------|---------|-------|-----|--------|
+| AT32F435CGU7 | QFN48 | 1MB | 384KB | ✅ Full Support |
+| AT32F435RGT7 | LQFP64 | 1MB | 384KB | ✅ Full Support |
+| AT32F437VMT7 | LQFP100 | 4MB | 384KB | ✅ Full Support |
+
+### STM32 Series
+
+| Chip | Package | Flash | RAM | Status |
+|------|---------|-------|-----|--------|
+| STM32G474CGU6 | QFN48 | 512KB | 128KB | 🚧 In Development |
+| STM32G473CGU6 | QFN48 | 512KB | 128KB | 🚧 In Development |
 
 ---
 
 ## Supported Sensors
 
-### Gyro/Accelerometer
+### Gyroscope / Accelerometer
 
-| Sensor | Status |
-|--------|--------|
-| BMI270 | ✅ Full Support |
-| ICM-42688-P | ✅ Full Support |
-| QMI8658C | ✅ Full Support |
+| Sensor | Status | Notes |
+|--------|--------|-------|
+| BMI270 | ✅ Full Support | Recommended |
+| QMI8658C | ✅ Full Support | Recommended |
+| ICM42688P | ⚠️ Limited Support | Not recommended for new designs |
 
----
-
-## Where to Buy
-
-### NeutronRC
-
-- Official: [NeutronRC](https://www.neutronrc.com)
-- Taobao: Search "NeutronRC F435"
+:::warning[About ICM42688P Support]
+The ICM42688P currently receives only limited support and is **strongly discouraged** for any new flight controller designs. If you are developing a new flight controller or shopping for one, please prioritize units equipped with BMI270 or QMI8658C gyroscopes.
+:::
 
 ---
 
-## Adding New Board Support
+## Requesting Support for New Hardware
 
-If you're a flight controller manufacturer and want Fidelity X to support your board, please contact us via GitHub.
+If you are a flight controller manufacturer interested in official Fidelity X support for your product, please reach out to us via GitHub.

--- a/src/content/docs/zh/fydelix/flashing.md
+++ b/src/content/docs/zh/fydelix/flashing.md
@@ -111,10 +111,10 @@ bootloader
 
 | 飞控板 | 固件名称 |
 |--------|----------|
-| NeutronRC F435 SE | `fydelix-NeutronRCF435SE` |
-| NeutronRC F435 MINI | `fydelix-NeutronRCF435MINI` |
-| Hummingbird 200RS | `fydelix-Hummingbird200RS` |
-| Hummingbird 255 V1 | `fydelix-Hummingbird255V1REVA` |
+| NeutronRCF435SE | `fydelix-NeutronRCF435SE` |
+| NeutronRCF435MINI | `fydelix-NeutronRCF435MINI` |
+| Hummingbird200RS | `fydelix-Hummingbird200RS` |
+| Hummingbird255V1 | `fydelix-Hummingbird255V1REVA` |
 | StingerBee | `fydelix-StingerBee` |
 
 ---

--- a/src/content/docs/zh/fydelix/supported-boards.md
+++ b/src/content/docs/zh/fydelix/supported-boards.md
@@ -1,29 +1,35 @@
 ---
 title: 支持的硬件
-description: Fidelity X 支持的飞控板和传感器
+description: Fidelity X 支持的飞控与传感器一览
 ---
 
-Fidelity X 支持多款基于 AT32F43x 的飞控板。
+Fidelity X 目前支持多款基于 AT32F43x 系列 MCU 的飞控。
 
 ---
 
-## 官方支持的飞控板
+## 官方支持的飞控
 
-以下飞控板经过完整测试，提供官方支持：
+以下飞控均经过完整测试，享有官方支持：
 
 ### NeutronRC 系列
 
-#### NeutronRC F435 SE
+#### NeutronRCF435SE
 
 | 项目 | 规格 |
 |------|------|
 | MCU | AT32F435RGT7 |
 | 封装 | LQFP64 |
 | 陀螺仪 | BMI270 |
-| 尺寸 | 30.5 x 30.5mm |
+| 孔距 | 20x20mm / 30.5x30.5mm |
 | 固件 | `fydelix-NeutronRCF435SE` |
 
-#### NeutronRC F435 MINI
+一款经典的多用途飞控，兼容 20x20mm 与 30.5x30.5mm 两种安装孔距，适配性极佳。
+
+:::danger[购买前必读]
+NeutronRC 已推出同名的新版 F435SE，但采用了 **ICM42688P** 陀螺仪。**Fidelity X 不兼容该新版本**。选购时请务必向卖家确认陀螺仪型号为 **BMI270**。
+:::
+
+#### NeutronRCF435MINI
 
 | 项目 | 规格 |
 |------|------|
@@ -33,95 +39,140 @@ Fidelity X 支持多款基于 AT32F43x 的飞控板。
 | 尺寸 | 20 x 20mm |
 | 固件 | `fydelix-NeutronRCF435MINI` |
 
+常见于 NeutronRC 的 AIO（All-In-One）一体化产品中。
+
+:::caution[注意事项]
+- **陀螺仪限制**：仅支持搭载 BMI270 的版本；部分采用 ICM42688P 的变体机型不受支持
+- **ESC 固件要求**：仅兼容 **Bluejay**、**AM32** 及 **BLHeli_32**，暂无其他 ESC 固件的支持计划
+:::
+
 ---
 
-### Hummingbird 系列
+### NewBeeDrone 系列
 
 #### Hummingbird 200RS
 
 | 项目 | 规格 |
 |------|------|
 | MCU | AT32F435 |
-| 陀螺仪 | BMI270 / ICM-42688-P |
+| 陀螺仪 | BMI270 / ICM42688P |
 | 尺寸 | 20 x 20mm |
-| 固件 | `fydelix-Hummingbird200RS` |
+| 固件 | `fydelix-Hummingbird200RS` / `fydelix-Hummingbird200RS_legacy` |
 
 #### Hummingbird 255 V1
 
 | 项目 | 规格 |
 |------|------|
 | MCU | AT32F435 |
-| 陀螺仪 | BMI270 |
+| 陀螺仪 | BMI270 / ICM42688P |
 | 尺寸 | 25.5 x 25.5mm |
-| 固件 | `fydelix-Hummingbird255V1REVA` |
+| 固件 | `fydelix-Hummingbird255V1REVA` / `fydelix-Hummingbird255V1REVA_legacy` |
 
----
-
-### 其他飞控
+:::tip[如何选择固件]
+Hummingbird 系列存在两种陀螺仪变体，刷机前请先确认你的硬件版本：
+- **无 `_legacy` 后缀**：适用于 **BMI270** 陀螺仪
+- **带 `_legacy` 后缀**：适用于 **ICM42688P** 陀螺仪
+:::
 
 #### StingerBee
 
 | 项目 | 规格 |
 |------|------|
 | MCU | AT32F435 |
-| 陀螺仪 | BMI270 |
+| 陀螺仪 | ICM42688P |
+| 类型 | BNF 到手飞套机 |
 | 适用 | Tiny Whoop |
 | 固件 | `fydelix-StingerBee` |
 
+StingerBee 是 NewBeeDrone 推出的 BNF（Bind-and-Fly）到手飞套机，并非独立销售的飞控板。
+
+:::note[厂家预设说明]
+StingerBee 固件内置了由 NewBeeDrone 定制的出厂预设。执行恢复出厂设置时，系统将还原至 **NewBeeDrone 厂家预设**，而非 Fidelity X 的默认参数。
+:::
+
 ---
 
-## 选择正确的固件
+### 开源设计方案
 
-### 固件命名规则
+#### ESMRPROTO2
 
-```
-fydelix-<飞控型号>-<版本号>-<提交号>.hex
+| 项目 | 规格 |
+|------|------|
+| MCU | AT32F435 |
+| 陀螺仪 | BMI270 / ICM42688P |
+| 类型 | 开源硬件设计 |
+| 固件 | `fydelix-ESMRPROTO2` / `fydelix-ESMRPROTO2_legacy` |
+
+ESMRPROTO2 是一款广受欢迎的开源飞控原理图设计，被众多商业飞控厂商及 DIY 爱好者采用。如果你的飞控基于此设计，可尝试使用本固件。
+
+:::tip[如何选择固件]
+固件选择规则与 Hummingbird 系列一致：
+- **无 `_legacy` 后缀**：适用于 **BMI270** 陀螺仪
+- **带 `_legacy` 后缀**：适用于 **ICM42688P** 陀螺仪
+:::
+
+---
+
+## 固件选择指南
+
+### 命名规则
+
+```text
+fydelix-<飞控型号>-<版本号>-<Git提交哈希>.hex
 ```
 
 **示例**：`fydelix-NeutronRCF435MINI-0.1.3-8ab496d.hex`
 
-### Legacy 版本
+### Legacy 版本说明
 
-部分飞控有 `_legacy` 后缀的固件，用于兼容旧版硬件。
+带有 `_legacy` 后缀的固件专为搭载 **ICM42688P** 陀螺仪的飞控设计。
 
-:::tip[如何选择]
-- 先尝试普通版本
-- 如果遇到问题，再试 legacy 版本
+| 固件类型 | 适用陀螺仪 |
+|----------|------------|
+| 标准版本（无后缀） | BMI270 |
+| Legacy 版本（`_legacy` 后缀） | ICM42688P |
+
+:::caution[请勿刷错固件]
+刷入错误版本的固件将导致陀螺仪无法正常工作，飞控不能解锁。刷机前请务必确认你的飞控所搭载的陀螺仪型号。
 :::
 
 ---
 
 ## 支持的 MCU
 
-| 芯片 | 封装 | Flash | RAM |
-|------|------|-------|-----|
-| AT32F435CGU7 | QFN48 | 1MB | 384KB |
-| AT32F435RGT7 | LQFP64 | 1MB | 384KB |
-| AT32F437VMT7 | LQFP100 | 4MB | 512KB |
+### AT32 系列
+
+| 芯片型号 | 封装 | Flash | RAM | 支持状态 |
+|----------|------|-------|-----|----------|
+| AT32F435CGU7 | QFN48 | 1MB | 384KB | ✅ 完整支持 |
+| AT32F435RGT7 | LQFP64 | 1MB | 384KB | ✅ 完整支持 |
+| AT32F437VMT7 | LQFP100 | 4MB | 384KB | ✅ 完整支持 |
+
+### STM32 系列
+
+| 芯片型号 | 封装 | Flash | RAM | 支持状态 |
+|----------|------|-------|-----|----------|
+| STM32G474CGU6 | QFN48 | 512KB | 128KB | 🚧 开发中 |
+| STM32G473CGU6 | QFN48 | 512KB | 128KB | 🚧 开发中 |
 
 ---
 
 ## 支持的传感器
 
-### 陀螺仪/加速度计
+### 陀螺仪 / 加速度计
 
-| 传感器 | 状态 |
-|--------|------|
-| BMI270 | ✅ 完整支持 |
-| ICM-42688-P | ✅ 完整支持 |
-| QMI8658C | ✅ 完整支持 |
+| 传感器型号 | 支持状态 | 备注 |
+|------------|----------|------|
+| BMI270 | ✅ 完整支持 | 推荐首选 |
+| QMI8658C | ✅ 完整支持 | 推荐首选 |
+| ICM42688P | ⚠️ 有限支持 | 不建议用于新设计 |
 
----
-
-## 购买渠道
-
-### NeutronRC
-
-- 官方：[NeutronRC](https://www.neutronrc.com)
-- 淘宝：搜索 "NeutronRC F435"
+:::warning[关于 ICM42688P 的说明]
+ICM42688P 目前仅提供有限度的支持，我们 **强烈不建议** 将其用于任何新飞控的设计或选型。如果你正在设计新飞控或选购现成产品，请优先考虑搭载 BMI270 或 QMI8658C 的版本。
+:::
 
 ---
 
-## 添加新飞控支持
+## 申请新飞控适配
 
-如果你是飞控厂商，希望 Fidelity X 支持你的飞控板，请通过 GitHub 联系我们。
+如果你是飞控厂商，希望 Fidelity X 为你的产品提供官方支持，欢迎通过 GitHub 与我们联系。


### PR DESCRIPTION
Updated both English and Chinese documentation for supported boards and flashing instructions. Standardized board naming, clarified firmware selection for different gyroscope variants, added detailed hardware compatibility notes, and expanded tables for MCUs and sensors. Improved guidance for manufacturers and users regarding hardware support and firmware flashing.